### PR TITLE
Update/Addition of more utilities and help files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+# ignore .git and .cache folders and all markdown files
+.git
+.cache
+*.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:alpine
-MAINTAINER "Dave Ahr <dahr@vmware.com"
+MAINTAINER "Dave Ahr <dahr@vmware.com>"
 
 # Install libraries
 RUN echo "Installing Libraries" \
@@ -10,9 +10,10 @@ RUN echo "Installing Ansible Libs" \
 RUN echo "Installing AWS Libs" \
     && apk add --update groff less
 
-ENV TERRAFORM_VERSION=0.11.13
-ENV PACKER_VERSION=1.4.1
-ENV KUBECTL_VERSION=v1.12.7
+ENV TERRAFORM_VERSION=0.12.6
+ENV PACKER_VERSION=1.4.3
+ENV KUBECTL_VERSION=v1.14.5
+ENV BOSH_VERSION=6.0.0
 WORKDIR /
 
 # Install Terraform
@@ -81,6 +82,20 @@ RUN echo "Installing PKS CLI" \
   && which pks \
   && pks --version
 
+# Install Cloud Foundry Bosh CLI
+RUN echo "Installing Bosh CLI" \
+  && wget -q https://github.com/cloudfoundry/bosh-cli/releases/download/v${BOSH_VERSION}/bosh-cli-${BOSH_VERSION}-linux-amd64 \
+  && mv bosh-cli-${BOSH_VERSION}-linux-amd64 /usr/local/bin/bosh \
+  && chmod +x ./usr/local/bin/bosh \
+  && which bosh \
+  && bosh --version
+
+# Install Cloud Foundry UAAC
+RUN echo "Installing uaac" \
+  && apk add ruby ruby-dev ruby-rdoc \
+  && gem install cf-uaac \
+  && which uaac \
+  && uaac --version
+  
 # Create Aliases
 RUN echo "alias k=kubectl" > /root/.profile
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -99,3 +99,6 @@ RUN echo "Installing uaac" \
   
 # Create Aliases
 RUN echo "alias k=kubectl" > /root/.profile
+
+# Copy support files
+COPY bosh /root/bosh

--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # cli_container
-Build a container image with built in pks and kubectl cli
+This Dockerfile will build a container image with the following utilities:
+
+- Terraform
+- Packer
+- Ansible
+- AWS CLI
+- VKE
+- kubectl
+- Istioctl
+- Helm
+- PKS CLI
+- Bosh CLI
+- UAAC

--- a/bosh/bosh-env
+++ b/bosh/bosh-env
@@ -1,0 +1,7 @@
+# Bosh Environment Variables
+# Be sure to replace the below with your specific environment information
+
+export BOSH_CLIENT=ops_manager
+export BOSH_CLIENT_SECRET=some secret
+export BOSH_CA_CERT=/var/tempest/workspaces/default/root_ca_certificate
+export BOSH_ENVIRONMENT=10.0.0.5


### PR DESCRIPTION
Added:
- .dockerignore
- **Bosh CLI**
  - **bosh-env** added in _/root/bosh_
    - contains typical environment variables to set when using bosh
- **UAAC**
- **Packages**
  - _ruby_ (dep for UAAC install)
  - _ruby-dev_ (dep for UAAC install)
  - _ruby-rdoc_ (dep for UAAC install)
  - _openssh-server_

Modified:
- Missing ">" in MAINTAINER line